### PR TITLE
feat: Implement tag suggestion feature

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -140,6 +140,20 @@ app.post("/upload", upload.single("pdfFile"), async (req, res) => {
   }
 });
 
+// GET route for fetching all tags
+app.get('/api/tags', async (req, res) => {
+  try {
+    const stmt = db.prepare('SELECT name FROM tags ORDER BY name ASC');
+    const tagObjects = stmt.all(); // Returns an array of objects, e.g., [{name: 'tag1'}, {name: 'tag2'}]
+    const tagNames = tagObjects.map(tagObj => tagObj.name); // Extract just the names
+
+    res.json(tagNames);
+  } catch (error) {
+    console.error('Error fetching tags:', error);
+    res.status(500).json({ message: 'Failed to fetch tags', error: error.message });
+  }
+});
+
 // Serve static files from the 'uploads' directory
 // Make sure this is also correctly handling potential special characters in filenames if necessary
 // express.static by default uses 'send' which handles Content-Disposition and ETag, and should be fine.


### PR DESCRIPTION
Backend:
- I added a new GET endpoint `/api/tags` that retrieves all unique tag names from the database, ordered alphabetically.

Frontend (FileUploadForm.jsx):
- I replaced the previous tag input (Select mode="tags") with a new system using Ant Design's AutoComplete and Tag components.
- On component mount, I made it fetch all existing tags from `/api/tags`.
- As you type in the AutoComplete input field:
  - Suggestions are shown from the fetched list of existing tags.
  - Suggestions are filtered based on the input and exclude already selected tags.
- You can add tags by:
  - Typing a new tag and pressing Enter.
  - Selecting a tag from the AutoComplete suggestions.
- Selected tags are displayed as closable Ant Design Tag components.
- I handled state management for current input, selected tags, and AutoComplete options within the component.
- I maintained integration with the parent component (App.jsx) via `onTagsChange` (sending a comma-separated string).