### PR TITLE
fix: Resolve "Maximum update depth exceeded" error

### DIFF
--- a/frontend/pdf-uploader-ui/src/App.jsx
+++ b/frontend/pdf-uploader-ui/src/App.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useCallback } from "react";
 // import "./App.css"; // Removed as per instructions
 import FileUploadForm from "./components/FileUploadForm";
 import QRCodeDisplay from "./components/QRCodeDisplay";
@@ -17,24 +17,24 @@ function App() {
   const [fileName, setFileName] = useState("");
   const [tags, setTags] = useState("");
 
-  const handleFileChange = (event) => {
+  const handleFileChange = useCallback((event) => {
     // For Antd Upload, event itself is the file list.
     // For standard input, it's event.target.files.
     // The FileUploadForm is now antd, but its onFileChange prop expects { target: { files: [file] } }
     // This handler in App.jsx is correctly expecting an event-like object from FileUploadForm's onFileChange.
     setSelectedFile(event.target.files[0]);
     setErrorMessage(""); // Clear previous errors
-  };
+  }, []); // setSelectedFile and setErrorMessage are stable
 
-  const handleFileNameChange = (event) => {
+  const handleFileNameChange = useCallback((event) => {
     setFileName(event.target.value);
-  };
+  }, []); // setFileName is stable
 
-  const handleTagsChange = (event) => {
+  const handleTagsChange = useCallback((event) => {
     setTags(event.target.value);
-  };
+  }, []); // setTags is stable
 
-  const handleUpload = async () => {
+  const handleUpload = useCallback(async () => {
     if (!selectedFile) {
       setErrorMessage("Please select a PDF file first.");
       return;
@@ -84,11 +84,11 @@ function App() {
     } finally {
       setUploading(false);
     }
-  };
+  }, [selectedFile, fileName, tags]); // State setters are stable and not needed here
 
-  const handlePrintQrCode = () => {
+  const handlePrintQrCode = useCallback(() => {
     window.print();
-  };
+  }, []); // No dependencies
 
   return (
     <Layout className="layout">

--- a/frontend/pdf-uploader-ui/src/components/FileUploadForm.jsx
+++ b/frontend/pdf-uploader-ui/src/components/FileUploadForm.jsx
@@ -57,8 +57,12 @@ function FileUploadForm(props) {
 
   // Effect to update props.onTagsChange when selectedTagValues changes
   useEffect(() => {
-    onTagsChange({ target: { value: selectedTagValues.join(',') } });
-  }, [selectedTagValues, onTagsChange]);
+    const newTagsString = selectedTagValues.join(',');
+    // props.tags is the current comma-separated string from App.jsx
+    if (newTagsString !== props.tags) {
+      props.onTagsChange({ target: { value: newTagsString } });
+    }
+  }, [selectedTagValues, props.tags, props.onTagsChange]); // Add props.tags to dependency array
   
   const handleTagChange = (newSelectedValues) => {
     // Filter out any empty strings that might be introduced if user creates an empty tag


### PR DESCRIPTION
- Memoized event handler props (`handleFileChange`, `handleFileNameChange`, `handleTagsChange`, `handleUpload`, `handlePrintQrCode`) in `App.jsx` using `useCallback` to ensure stable references.
- Refined the `useEffect` hook in `FileUploadForm.jsx` that calls `onTagsChange`:
  - It now conditionally calls `onTagsChange` only if the new tag string value differs from your current `props.tags` value.
  - Updated the dependency array of this `useEffect` to correctly include `props.tags` and the memoized `props.onTagsChange`.

These changes prevent an infinite loop of re-renders that was occurring after a file upload when the form state was reset.