### PR TITLE
feat: Temporarily move printable-area for print diagnostics

### DIFF
--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react'; // Ensure Fragment is imported
 import { Button, Card, Typography, Image, Space } from 'antd';
 import { PrinterOutlined } from '@ant-design/icons';
 
@@ -8,21 +8,24 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, handlePrintQrCode, fileName, tag
   }
 
   return (
-    <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
+    <Fragment>
       <div id="printable-area">
         <h1>{fileName || "Name not available"}</h1>
         <h3>{tags || "Tags not available"}</h3>
         <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />
       </div>
-      <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
-        <Typography.Text>
-          PDF Link: <Typography.Link href={pdfUrl} target="_blank" rel="noopener noreferrer">{pdfUrl}</Typography.Link>
-        </Typography.Text>
-        <Button type="primary" icon={<PrinterOutlined />} onClick={handlePrintQrCode}>
-          Print QR Code & PDF Link
-        </Button>
-      </Space>
-    </Card>
+      <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
+        {/* div#printable-area was here, now moved above Card */}
+        <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
+          <Typography.Text>
+            PDF Link: <Typography.Link href={pdfUrl} target="_blank" rel="noopener noreferrer">{pdfUrl}</Typography.Link>
+          </Typography.Text>
+          <Button type="primary" icon={<PrinterOutlined />} onClick={handlePrintQrCode}>
+            Print QR Code & PDF Link
+          </Button>
+        </Space>
+      </Card>
+    </Fragment>
   );
 }
 


### PR DESCRIPTION
For diagnostic purposes, this commit temporarily alters QRCodeDisplay.jsx to render the div#printable-area as a sibling to the Ant Design Card, rather than its child.

This is to test whether the Card component's styles are interfering with the application of print-specific styles that are intended to hide all other elements.