### PR TITLE
feat: Implement printing with react-to-print

### DIFF
--- a/frontend/pdf-uploader-ui/package-lock.json
+++ b/frontend/pdf-uploader-ui/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "antd": "^5.25.2",
         "react": "^19.1.0",
-        "react-dom": "^19.1.0"
+        "react-dom": "^19.1.0",
+        "react-to-print": "^3.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
@@ -2490,6 +2491,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-to-print": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/react-to-print/-/react-to-print-3.1.0.tgz",
+      "integrity": "sha512-hiJZVmJtaRm9EHoUTG2bordyeRxVSGy9oFVV7fSvzOWwctPp6jbz2R6NFkaokaTYBxC7wTM/fMV5eCXsNpEwsA==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ~19"
       }
     },
     "node_modules/resize-observer-polyfill": {

--- a/frontend/pdf-uploader-ui/package.json
+++ b/frontend/pdf-uploader-ui/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "antd": "^5.25.2",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "react-to-print": "^3.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/frontend/pdf-uploader-ui/src/App.css
+++ b/frontend/pdf-uploader-ui/src/App.css
@@ -116,50 +116,32 @@ body {
 }
 
 @media print {
-      /* Hide everything by default */
-      body, body * {
-        display: none !important;
-        visibility: hidden !important; /* Adding for extra measure */
-      }
+  /* Ensure a white background for the printed area if not default */
+  #printable-area {
+    background-color: #fff !important; 
+  }
 
-      /* Make printable-area and its contents visible and styled */
-      #printable-area {
-        display: block !important;
-        visibility: visible !important;
-        position: absolute;
-        left: 0px; /* Corrected unit */
-        top: 0px;  /* Corrected unit */
-        width: 100%;
-        padding: 20px;
-        margin: 0px; /* Corrected unit */
-        background-color: #fff !important;
-        z-index: 9999 !important; /* Ensure it's on top */
-      }
+  #printable-area h1 {
+    text-align: center;
+    font-size: 20pt;
+    color: #000 !important; /* Ensure black text for print */
+    margin-top: 0; /* Or specific print margin */
+    margin-bottom: 10px;
+  }
 
-      #printable-area h1 {
-        display: block !important;
-        visibility: visible !important;
-        text-align: center;
-        font-size: 20pt !important;
-        color: #000 !important;
-        margin-top: 0px; /* Corrected unit */
-        margin-bottom: 10px;
-      }
+  #printable-area h3 {
+    text-align: center;
+    font-size: 14pt;
+    color: #000 !important; /* Ensure black text for print */
+    margin-bottom: 15px;
+  }
 
-      #printable-area h3 {
-        display: block !important;
-        visibility: visible !important;
-        text-align: center;
-        font-size: 14pt !important;
-        color: #000 !important;
-        margin-bottom: 15px;
-      }
-
-      #printable-area img { /* QR Code */
-        display: block !important;
-        visibility: visible !important;
-        max-width: 80mm !important;
-        margin: 20px auto !important;
-        border: 1px solid #000 !important;
-      }
-    }
+  #printable-area img { /* QR Code */
+    max-width: 80mm; /* Or desired print size */
+    display: block;
+    margin: 20px auto;
+    border: 1px solid #000; /* Optional: border for the image */
+  }
+  
+  /* Add any other styles specifically needed for the content of #printable-area when printed */
+}

--- a/frontend/pdf-uploader-ui/src/App.jsx
+++ b/frontend/pdf-uploader-ui/src/App.jsx
@@ -96,9 +96,9 @@ function App() {
     }
   }, [selectedFile, fileName, tags]); // State setters are stable and not needed here
 
-  const handlePrintQrCode = useCallback(() => {
-    window.print();
-  }, []); // No dependencies
+  // const handlePrintQrCode = useCallback(() => {
+  //   window.print();
+  // }, []); // No dependencies - This function is removed
 
   return (
     <Layout className="layout">
@@ -125,7 +125,7 @@ function App() {
               <QRCodeDisplay
                 qrCodeDataUrl={qrCodeDataUrl}
                 pdfUrl={pdfUrl}
-                handlePrintQrCode={handlePrintQrCode}
+                // handlePrintQrCode={handlePrintQrCode} // This prop is removed
                 fileName={fileName}
                 tags={tags}
               />

--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -1,31 +1,35 @@
-import React, { Fragment } from 'react'; // Ensure Fragment is imported
+import React, { useRef } from 'react'; // Add useRef
+import { useReactToPrint } from 'react-to-print'; // Add this import
 import { Button, Card, Typography, Image, Space } from 'antd';
 import { PrinterOutlined } from '@ant-design/icons';
 
-function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, handlePrintQrCode, fileName, tags }) {
+function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) { // Removed handlePrintQrCode
   if (!qrCodeDataUrl) {
     return null;
   }
 
+  const printableAreaRef = useRef();
+
+  const handlePrint = useReactToPrint({
+    content: () => printableAreaRef.current,
+  });
+
   return (
-    <Fragment>
-      <div id="printable-area">
+    <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
+      <div id="printable-area" ref={printableAreaRef}>
         <h1>{fileName || "Name not available"}</h1>
         <h3>{tags || "Tags not available"}</h3>
         <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />
       </div>
-      <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
-        {/* div#printable-area was here, now moved above Card */}
-        <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
-          <Typography.Text>
-            PDF Link: <Typography.Link href={pdfUrl} target="_blank" rel="noopener noreferrer">{pdfUrl}</Typography.Link>
-          </Typography.Text>
-          <Button type="primary" icon={<PrinterOutlined />} onClick={handlePrintQrCode}>
-            Print QR Code & PDF Link
-          </Button>
-        </Space>
-      </Card>
-    </Fragment>
+      <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
+        <Typography.Text>
+          PDF Link: <Typography.Link href={pdfUrl} target="_blank" rel="noopener noreferrer">{pdfUrl}</Typography.Link>
+        </Typography.Text>
+        <Button type="primary" icon={<PrinterOutlined />} onClick={handlePrint}>
+          Print QR Code & PDF Link
+        </Button>
+      </Space>
+    </Card>
   );
 }
 


### PR DESCRIPTION
Replaces the previous window.print() and manual CSS print styling with the `react-to-print` library for more robust and cleaner print functionality.

Changes include:
- Added `react-to-print` as a dependency.
- Modified `QRCodeDisplay.jsx` to use the `useReactToPrint` hook, targeting the `div#printable-area` for printing.
- Removed the manual print handler from `App.jsx`.
- Simplified `@media print` styles in `App.css` to only include styling for the content within `div#printable-area`, as `react-to-print` handles component isolation.