### PR TITLE
feat: Temporarily remove Image for react-to-print diagnostics

### DIFF
--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -19,7 +19,7 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) { // Removed h
       <div id="printable-area" ref={printableAreaRef}>
         <h1>{fileName || "Name not available"}</h1>
         <h3>{tags || "Tags not available"}</h3>
-        <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />
+        {/* <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} /> */} {/* Temporarily commented out/removed */}
       </div>
       <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
         <Typography.Text>


### PR DESCRIPTION
For diagnostic purposes, this commit temporarily comments out the Ant Design Image component within the printable area in QRCodeDisplay.jsx.

This is to test if the Image component is interfering with react-to-print's ref handling, which was causing a "did not receive contentRef" error.