### PR TITLE
Here's the rewritten message:

### DIFF
--- a/frontend/pdf-uploader-ui/src/App.css
+++ b/frontend/pdf-uploader-ui/src/App.css
@@ -117,11 +117,12 @@ body {
 
 @media print {
   /* Ensure a white background for the printed area if not default */
-  #printable-area {
+  #actual-printable-content {
     background-color: #fff !important; 
+    /* Ensure any other necessary base styles for the printable block are here */
   }
 
-  #printable-area h1 {
+  #actual-printable-content h1 {
     text-align: center;
     font-size: 20pt;
     color: #000 !important; /* Ensure black text for print */
@@ -129,19 +130,19 @@ body {
     margin-bottom: 10px;
   }
 
-  #printable-area h3 {
+  #actual-printable-content h3 {
     text-align: center;
     font-size: 14pt;
     color: #000 !important; /* Ensure black text for print */
     margin-bottom: 15px;
   }
 
-  #printable-area img { /* QR Code */
+  #actual-printable-content img { /* QR Code */
     max-width: 80mm; /* Or desired print size */
     display: block;
     margin: 20px auto;
     border: 1px solid #000; /* Optional: border for the image */
   }
   
-  /* Add any other styles specifically needed for the content of #printable-area when printed */
+  /* Add any other styles specifically needed for the content of #actual-printable-content when printed */
 }

--- a/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
+++ b/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Image } from 'antd'; // Assuming Image component is from antd
+
+const PrintableContent = React.forwardRef((props, ref) => {
+  const { fileName, tags, qrCodeDataUrl } = props;
+
+  return (
+    <div id="actual-printable-content" ref={ref} style={{ background: 'white' }}> {/* Added white background style */}
+      <h1>{fileName || "Name not available"}</h1>
+      <h3>{tags || "Tags not available"}</h3>
+      {qrCodeDataUrl && <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />}
+    </div>
+  );
+});
+
+export default PrintableContent;

--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -1,14 +1,15 @@
-import React, { useRef } from 'react'; // Add useRef
-import { useReactToPrint } from 'react-to-print'; // Add this import
+import React, { useRef } from 'react';
+import { useReactToPrint } from 'react-to-print';
 import { Button, Card, Typography, Image, Space } from 'antd';
 import { PrinterOutlined } from '@ant-design/icons';
+import PrintableContent from './PrintableContent'; // Import the new component
 
-function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) { // Removed handlePrintQrCode
+function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
   if (!qrCodeDataUrl) {
     return null;
   }
 
-  const printableAreaRef = useRef();
+  const printableAreaRef = useRef(); // Ref for the PrintableContent component
 
   const handlePrint = useReactToPrint({
     content: () => printableAreaRef.current,
@@ -16,11 +17,23 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) { // Removed h
 
   return (
     <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
-      <div id="printable-area" ref={printableAreaRef}>
+      {/* Hidden component for printing */}
+      <div style={{ display: 'none' }}>
+        <PrintableContent 
+          ref={printableAreaRef} 
+          fileName={fileName} 
+          tags={tags} 
+          qrCodeDataUrl={qrCodeDataUrl} 
+        />
+      </div>
+
+      {/* Visible content for on-screen display */}
+      <div> 
         <h1>{fileName || "Name not available"}</h1>
         <h3>{tags || "Tags not available"}</h3>
-        {/* <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} /> */} {/* Temporarily commented out/removed */}
+        {qrCodeDataUrl && <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />}
       </div>
+
       <Space direction="vertical" align="center" size="middle" style={{ width: '100%' }}>
         <Typography.Text>
           PDF Link: <Typography.Link href={pdfUrl} target="_blank" rel="noopener noreferrer">{pdfUrl}</Typography.Link>


### PR DESCRIPTION
feat: Implement react-to-print with dedicated component

I've refactored the printing mechanism to use `react-to-print` with a dedicated, hidden `PrintableContent` component. This approach is often more robust for handling refs and ensuring correct print output.

Changes:
- I reverted a previous diagnostic change (uncommented Image in QRCodeDisplay).
- I created `PrintableContent.jsx`, a forwardRef component that renders the content intended for printing (H1 name, H3 tags, QR Image). This component uses `id="actual-printable-content"`.
- I modified `QRCodeDisplay.jsx` to render a hidden instance of `PrintableContent` and pass its ref to `useReactToPrint`. The visible UI is rendered separately.
- I updated print styles in `App.css` to target `#actual-printable-content` instead of the old `#printable-area`.