### PR TITLE
debug: Add console logging for react-to-print ref

### DIFF
--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -10,10 +10,28 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
   }
 
   const printableAreaRef = useRef(); // Ref for the PrintableContent component
+  console.log("QRCodeDisplay: printableAreaRef initialized", printableAreaRef); // Log initial ref object
 
   const handlePrint = useReactToPrint({
-    content: () => printableAreaRef.current,
+    content: () => {
+      console.log("useReactToPrint content() called. printableAreaRef.current:", printableAreaRef.current);
+      return printableAreaRef.current;
+    },
+    onBeforeGetContent: () => {
+      console.log("useReactToPrint onBeforeGetContent() called. printableAreaRef.current:", printableAreaRef.current);
+      return Promise.resolve(); // Required by onBeforeGetContent
+    },
+    onPrintError: (errorLocation, error) => {
+      // Log the error location and the error object itself
+      console.error("useReactToPrint onPrintError:", errorLocation, error);
+      // It might be useful to see the state of printableAreaRef.current here too, if possible,
+      // but the error object itself is more critical.
+      console.error("useReactToPrint onPrintError - printableAreaRef.current at time of error:", printableAreaRef.current);
+    }
   });
+
+  // Log right before the return statement of QRCodeDisplay
+  console.log("QRCodeDisplay: printableAreaRef before return statement. Current value:", printableAreaRef.current);
 
   return (
     <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>


### PR DESCRIPTION
Adds extensive console logging in QRCodeDisplay.jsx to track the value of `printableAreaRef.current` at various stages. This is to help you diagnose the persistent "did not receive contentRef" error from `react-to-print`.