### PR TITLE
fix: Use off-screen hiding for react-to-print component

### DIFF
--- a/frontend/pdf-uploader-ui/src/App.css
+++ b/frontend/pdf-uploader-ui/src/App.css
@@ -146,3 +146,15 @@ body {
   
   /* Add any other styles specifically needed for the content of #actual-printable-content when printed */
 }
+
+.visually-hidden-for-print-ref {
+  position: absolute !important; /* Use !important to ensure override */
+  left: -9999px !important;
+  top: -9999px !important;
+  width: 1px !important;
+  height: 1px !important;
+  overflow: hidden !important;
+  border: 0 !important; /* Ensure no border contributes to layout */
+  padding: 0 !important; /* Ensure no padding contributes to layout */
+  margin: 0 !important; /* Ensure no margin contributes to layout */
+}

--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -35,8 +35,8 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
 
   return (
     <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
-      {/* Hidden component for printing */}
-      <div style={{ display: 'none' }}>
+      {/* Hidden component for printing, using off-screen technique */}
+      <div className="visually-hidden-for-print-ref">
         <PrintableContent 
           ref={printableAreaRef} 
           fileName={fileName} 


### PR DESCRIPTION
Replaces `display: none` with an off-screen positioning CSS class (`.visually-hidden-for-print-ref`) for the hidden `PrintableContent` component instance used by `react-to-print`.

This change aims to ensure that React reliably assigns the ref to `printableAreaRef.current` by keeping the component technically in the layout tree, which might resolve the "did not receive contentRef" error.

Console logging for debugging the ref remains in place.