### PR TITLE
debug: Simplify PrintableContent and verify hiding CSS

### DIFF
--- a/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
+++ b/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
@@ -1,14 +1,30 @@
 import React from 'react';
-import { Image } from 'antd'; // Assuming Image component is from antd
+// Image import might not be needed if we are removing it for this diagnostic step.
+// However, to minimize changes if we revert, let's keep it for now.
+import { Image } from 'antd'; 
 
 const PrintableContent = React.forwardRef((props, ref) => {
-  const { fileName, tags, qrCodeDataUrl } = props;
+  console.log("PrintableContent: Rendering. Props received:", props); // Added console.log
+
+  const { fileName } = props; // Only need fileName for this simplified version
 
   return (
-    <div id="actual-printable-content" ref={ref} style={{ background: 'white' }}> {/* Added white background style */}
-      <h1>{fileName || "Name not available"}</h1>
-      <h3>{tags || "Tags not available"}</h3>
-      {qrCodeDataUrl && <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />}
+    <div 
+      id="actual-printable-content" 
+      ref={ref} 
+      style={{ 
+        border: '2px solid red', 
+        background: 'yellow', 
+        padding: '10px', 
+        marginTop: '10px', // Add some margin to separate from other content if visible
+        minWidth: '50px', // Ensure it has some dimension
+        minHeight: '50px' // Ensure it has some dimension
+      }}
+    >
+      <p>PRINTABLE CONTENT (Debug):</p>
+      <p>File Name: {fileName || "No Filename Prop Provided"}</p>
+      {/* The H1, H3, and Image are temporarily removed for this diagnostic step */}
+      {/* We are testing the ref assignment to this div itself */}
     </div>
   );
 });


### PR DESCRIPTION
- Simplified `PrintableContent.jsx` to basic content and added highly visible debug styling (yellow background, red border) and a console log to trace its rendering. This is to help diagnose ref assignment issues with `react-to-print`.
- Verified that the `.visually-hidden-for-print-ref` CSS class in `App.css` is correctly defined.

This commit is for further debugging of the persistent `react-to-print` error and issues with visually hiding the component instance used for printing.