### PR TITLE
fix: Correct conditional hook call in QRCodeDisplay

### DIFF
--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -5,12 +5,9 @@ import { PrinterOutlined } from '@ant-design/icons';
 import PrintableContent from './PrintableContent'; // Import the new component
 
 function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
-  if (!qrCodeDataUrl) {
-    return null;
-  }
-
-  const printableAreaRef = useRef(); // Ref for the PrintableContent component
-  console.log("QRCodeDisplay: printableAreaRef initialized", printableAreaRef); // Log initial ref object
+  // 1. Call ALL hooks at the top level, unconditionally.
+  const printableAreaRef = useRef();
+  console.log("QRCodeDisplay: printableAreaRef initialized", printableAreaRef); 
 
   const handlePrint = useReactToPrint({
     content: () => {
@@ -19,16 +16,18 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
     },
     onBeforeGetContent: () => {
       console.log("useReactToPrint onBeforeGetContent() called. printableAreaRef.current:", printableAreaRef.current);
-      return Promise.resolve(); // Required by onBeforeGetContent
+      return Promise.resolve();
     },
     onPrintError: (errorLocation, error) => {
-      // Log the error location and the error object itself
       console.error("useReactToPrint onPrintError:", errorLocation, error);
-      // It might be useful to see the state of printableAreaRef.current here too, if possible,
-      // but the error object itself is more critical.
       console.error("useReactToPrint onPrintError - printableAreaRef.current at time of error:", printableAreaRef.current);
     }
   });
+
+  // 2. The early conditional return `if (!qrCodeDataUrl) { return null; }` has been removed.
+  // App.jsx is expected to handle conditional rendering of QRCodeDisplay.
+  // If QRCodeDisplay is rendered, qrCodeDataUrl should be present.
+  // If not, PrintableContent and the visible Image should handle empty qrCodeDataUrl prop gracefully.
 
   // Log right before the return statement of QRCodeDisplay
   console.log("QRCodeDisplay: printableAreaRef before return statement. Current value:", printableAreaRef.current);


### PR DESCRIPTION
Restructures QRCodeDisplay.jsx to ensure that React Hooks (useRef, useReactToPrint) are called unconditionally at the top level of the component, before any conditional return statements. This resolves the "React Hook 'useRef' is called conditionally" error.

The early return `if (!qrCodeDataUrl)` was also removed, as the parent App.jsx already handles conditional rendering of QRCodeDisplay. This ensures the component's hook consistency if it is rendered.

Debug logging for react-to-print refs remains in place.