### PR TITLE
I've strengthened the CSS for `.visually-hidden-for-print-ref`.

### DIFF
--- a/frontend/pdf-uploader-ui/src/App.css
+++ b/frontend/pdf-uploader-ui/src/App.css
@@ -148,6 +148,7 @@ body {
 }
 
 .visually-hidden-for-print-ref {
+  display: block !important; /* Added */
   position: absolute !important; /* Use !important to ensure override */
   left: -9999px !important;
   top: -9999px !important;
@@ -157,4 +158,5 @@ body {
   border: 0 !important; /* Ensure no border contributes to layout */
   padding: 0 !important; /* Ensure no padding contributes to layout */
   margin: 0 !important; /* Ensure no margin contributes to layout */
+  z-index: -1 !important; /* Added */
 }


### PR DESCRIPTION
I added `display: block !important;` and `z-index: -1 !important;` to the `.visually-hidden-for-print-ref` class in App.css. This should make the off-screen hiding of the component used by react-to-print more robust, as it was previously still visible on your screen.

I've left the debug styling and logging in place for further diagnostics.