### PR TITLE
I'm currently trying to apply direct inline styles to the `div` that …

### DIFF
--- a/frontend/pdf-uploader-ui/src/App.css
+++ b/frontend/pdf-uploader-ui/src/App.css
@@ -118,7 +118,7 @@ body {
 @media print {
   /* Ensure a white background for the printed area if not default */
   #actual-printable-content {
-    background-color: #fff !important; 
+    background-color: #fff !important;
     /* Ensure any other necessary base styles for the printable block are here */
   }
 

--- a/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
+++ b/frontend/pdf-uploader-ui/src/components/PrintableContent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 // Image import might not be needed if we are removing it for this diagnostic step.
 // However, to minimize changes if we revert, let's keep it for now.
-import { Image } from 'antd'; 
+import { Image } from 'antd';
 
 const PrintableContent = React.forwardRef((props, ref) => {
   console.log("PrintableContent: Rendering. Props received:", props); // Added console.log
@@ -9,13 +9,13 @@ const PrintableContent = React.forwardRef((props, ref) => {
   const { fileName } = props; // Only need fileName for this simplified version
 
   return (
-    <div 
-      id="actual-printable-content" 
-      ref={ref} 
-      style={{ 
-        border: '2px solid red', 
-        background: 'yellow', 
-        padding: '10px', 
+    <div
+      id="actual-printable-content"
+      ref={ref}
+      style={{
+        border: '2px solid red',
+        background: 'yellow',
+        padding: '10px',
         marginTop: '10px', // Add some margin to separate from other content if visible
         minWidth: '50px', // Ensure it has some dimension
         minHeight: '50px' // Ensure it has some dimension

--- a/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
+++ b/frontend/pdf-uploader-ui/src/components/QRCodeDisplay.jsx
@@ -7,7 +7,7 @@ import PrintableContent from './PrintableContent'; // Import the new component
 function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
   // 1. Call ALL hooks at the top level, unconditionally.
   const printableAreaRef = useRef();
-  console.log("QRCodeDisplay: printableAreaRef initialized", printableAreaRef); 
+  console.log("QRCodeDisplay: printableAreaRef initialized", printableAreaRef);
 
   const handlePrint = useReactToPrint({
     content: () => {
@@ -34,18 +34,32 @@ function QRCodeDisplay({ qrCodeDataUrl, pdfUrl, fileName, tags }) {
 
   return (
     <Card title="Scan QR Code or Open PDF" style={{ marginTop: '20px' }}>
-      {/* Hidden component for printing, using off-screen technique */}
-      <div className="visually-hidden-for-print-ref">
-        <PrintableContent 
-          ref={printableAreaRef} 
-          fileName={fileName} 
-          tags={tags} 
-          qrCodeDataUrl={qrCodeDataUrl} 
+      {/* Hidden component for printing, using aggressive inline styles */}
+      <div
+        style={{
+          position: 'absolute',
+          left: '-9999px',
+          top: '-9999px',
+          width: '1px',
+          height: '1px',
+          overflow: 'hidden',
+          border: '0', // Ensure no border
+          padding: '0', // Ensure no padding
+          margin: '0', // Ensure no margin
+          opacity: '0', // Make it transparent as well
+          zIndex: '-1' // Try to push it behind other elements
+        }}
+      >
+        <PrintableContent
+          ref={printableAreaRef}
+          fileName={fileName}
+          tags={tags}
+          qrCodeDataUrl={qrCodeDataUrl}
         />
       </div>
 
       {/* Visible content for on-screen display */}
-      <div> 
+      <div>
         <h1>{fileName || "Name not available"}</h1>
         <h3>{tags || "Tags not available"}</h3>
         {qrCodeDataUrl && <Image width={200} src={qrCodeDataUrl} alt="QR Code" preview={false} />}


### PR DESCRIPTION
…wraps `PrintableContent` in your `QRCodeDisplay.jsx` file. This is a diagnostic step to forcefully hide the component from the screen, bypassing potential issues with the external CSS class `.visually-hidden-for-print-ref`.

My goal here is to determine if hiding this component affects the persistent `react-to-print` "did not receive contentRef" error, assuming the ref itself is correctly assigned.

The debug styling on `PrintableContent` and console logs will remain in place for now.